### PR TITLE
add github action to run CI on pushes and PRs

### DIFF
--- a/.github/workflows/gtest-ci.yaml
+++ b/.github/workflows/gtest-ci.yaml
@@ -1,0 +1,26 @@
+
+name: GTest CI
+
+on: [push, pull_request]
+
+env:
+  TESTS_DIR: Google_tests
+  TESTS_EXEC: Google_Tests_run
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: CMake Generate
+      run: cmake -B ${{github.workspace}}/build -S .
+
+    - name: CMake Build
+      run: cmake --build ${{github.workspace}}/build
+
+    - name: Run tests
+      working-directory: ${{github.workspace}}/build/${{env.TESTS_DIR}}
+      run: ./${{env.TESTS_EXEC}}
+


### PR DESCRIPTION
### Problem:
Some PRs might add a breaking change, and the reviewer has to run the tests locally to make sure everything runs well.

### Solution
Add CI action to run PRs to avoid the hustle of pulling the new code and running the tests locally.

An example of a breaking change:
https://github.com/Ghost8345/Compiler-Generator/pull/14